### PR TITLE
Fix code scanning alert no. 1: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/vuln_apps/vulnado/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/vuln_apps/vulnado/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -64,7 +64,7 @@ public class Postgres {
         try {
 
             // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
 
             // digest() method is called to calculate message digest
             //  of an input digest() return array of byte


### PR DESCRIPTION
Fixes [https://github.com/Erika-Maggi/devsecops-exercises/security/code-scanning/1](https://github.com/Erika-Maggi/devsecops-exercises/security/code-scanning/1)

To fix the problem, we should replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm. A good choice would be SHA-256, which is part of the SHA-2 family and is widely regarded as secure.

- Replace `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code correctly handles the output of SHA-256, which produces a 256-bit hash value (32 bytes) instead of the 128-bit hash value (16 bytes) produced by MD5.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
